### PR TITLE
Acerto na geração do GetCacheKey

### DIFF
--- a/Converter/ConversionOptions.cs
+++ b/Converter/ConversionOptions.cs
@@ -35,8 +35,8 @@ namespace imageresizer.Converter
             // http://localhost:32772/api/images/resize/?name=image.big.jpg&format=png&width=500            
             var builder = new StringBuilder();
             builder.Append($"{fileName}.");
-            builder.Append($"w_{Width}");
-            builder.Append($",h_{Height}");
+            builder.Append($"w_{widthKey}");
+            builder.Append($",h_{heightKey}");
             builder.Append($",q_{Quality}");
             builder.Append(GetExtension());
             // image.big.w_500,h_0,q_100.png


### PR DESCRIPTION
Na composição da Key de cache da imagem não estava sendo contemplado o uso das variáveis widthKey e heightKey, que possuíam um teste que identificava o envio, ou não, de parâmetros para dimensionamento.

Apenas alterei as linhas 38 e 39 para contemplar as variáveis.